### PR TITLE
Allow robo 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "consolidation/robo": "^1.0",
+        "consolidation/robo": "^1.0|^2.0",
         "droath/robo-command-builder":  "~0.0.1"
     },
     "autoload": {


### PR DESCRIPTION
Complement to https://github.com/droath/robo-command-builder/pull/1.

I think the next tag for _droath/robo-command-builder_ will be 0.0.4, so I kept that dependency as-is.